### PR TITLE
CCP-1698: added a timeout for react slider styling on PDP page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.1] - 2019-09-11
+### Fixed
+* Added timeout to allow react-id-swiper to apply styling on PDP
+
 ## [1.1.0] - 2019-09-05
 ### Added
 - Configurable portal positions

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.1.1",
   "id": "@shopgate-project/product-recommendations",
   "components": [
     {

--- a/frontend/components/ProductSlider/index.jsx
+++ b/frontend/components/ProductSlider/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Slider from '../Slider';
 import withRecommendations from '../../connectors/withRecommendations';
@@ -13,6 +13,14 @@ import withRecommendations from '../../connectors/withRecommendations';
 const ProductSlider = ({
   type, id, limit, settings,
 }) => {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setReady(true);
+    }, 1);
+    return () => clearTimeout(timer);
+  });
+
   const ConnectedSlider = withRecommendations(
     Slider,
     {
@@ -23,7 +31,13 @@ const ProductSlider = ({
     }
   );
 
-  return <ConnectedSlider />;
+  if (!ready) {
+    return null;
+  }
+
+  return (
+    <ConnectedSlider />
+  );
 };
 
 ProductSlider.propTypes = {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-project/product-recommendations",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Extension will display retrieved product pipeline data from external providers. (ie. Boxalino, etc)",
   "license": "Apache-2.0",
   "scripts": {
@@ -12,15 +12,15 @@
     "dummy": ""
   },
   "devDependencies": {
-    "@shopgate/eslint-config": "^6.5.3",
-    "@shopgate/pwa-common": "^6.5.3",
-    "@shopgate/pwa-common-commerce": "^6.5.3",
-    "@shopgate/pwa-core": "^6.5.3",
-    "@shopgate/engage": "^6.5.3",
+    "@shopgate/eslint-config": "^6.7.1",
+    "@shopgate/pwa-common": "^6.7.1",
+    "@shopgate/pwa-common-commerce": "^6.7.1",
+    "@shopgate/pwa-core": "^6.7.1",
+    "@shopgate/engage": "^6.7.1",
     "jest": "^22.4.2",
-    "@shopgate/pwa-unit-test": "^6.5.3",
-    "@shopgate/pwa-ui-ios": "^6.5.3",
-    "@shopgate/pwa-ui-shared": "^6.5.3",
+    "@shopgate/pwa-unit-test": "^6.7.1",
+    "@shopgate/pwa-ui-ios": "^6.7.1",
+    "@shopgate/pwa-ui-shared": "^6.7.1",
     "babel-core": "^6.26.0",
     "babel-plugin-react-transform": "^3.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
@@ -41,6 +41,6 @@
     "react-transform-catch-errors": "^1.0.2"
   },
   "peerDependenciees": {
-    "@shopgate/engage": "^6.7.0"
+    "@shopgate/engage": "^6.7.1"
   }
 }


### PR DESCRIPTION
Heyo @Carsten89 I applied the same fix as: https://github.com/shopgate/ext-recently-viewed-products/pull/4 here.  Also seems to be related to https://github.com/shopgate/pwa/pull/774/files/
Please let me know if you have a better idea for this issue.
I tested with my shop: 31113 and attached https://github.com/shopgate-professional-services/ext-product-recommendations-mocked-backend. I changed the search param to: bumble to return a group of products since '*' didn't seem to return products for me. I also changed config to have:
{
  "cartPage": {
    "h2": "Unsere Empfehlungen",
    "h3": "Basierend auf deinem Warenkorb",
    "position": "cart.coupon-field.after",
    "textColor": "#fff",
    "background": "#3BAC5B"
  },
  "recommendationsPage": {
    "h2": "Deine persönlichen Empfehlungen",
    "h3": "Basierend auf den Daten die wir haben ;)",
    "title": "Deine Empfehlungen",
    "textColor": "#fff",
    "background": "#3BAC5B"
  },
  "productPage": {
    "h2": "Unsere Empfehlungen",
    "h3": "Kunden kauften auch",
    "position": "product.header.after",
    "textColor": "#fff",
    "background": "#3BAC5B"
  }
}

To recreate issue you must navigate to a product, navigate away, and return to product.