### PR TITLE
CCP-1698: Removed timeout workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - 2019-10-24
+## Fixed
+* Removed timeout workaround since it is no longer needed as of PWA 6.8+
+
 ## [1.1.2] - 2019-09-19
 ### Fixed
 * Added timeout to allow react-id-swiper to apply styling on PDP

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.2",
+  "version": "1.2.0",
   "id": "@shopgate-project/product-recommendations",
   "components": [
     {

--- a/frontend/components/ProductSlider/index.jsx
+++ b/frontend/components/ProductSlider/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Slider from '../Slider';
 import withRecommendations from '../../connectors/withRecommendations';
@@ -13,14 +13,6 @@ import withRecommendations from '../../connectors/withRecommendations';
 const ProductSlider = ({
   type, id, limit, settings,
 }) => {
-  const [ready, setReady] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setReady(true);
-    }, 1);
-    return () => clearTimeout(timer);
-  });
-
   const ConnectedSlider = withRecommendations(
     Slider,
     {
@@ -30,10 +22,6 @@ const ProductSlider = ({
       settings,
     }
   );
-
-  if (!ready) {
-    return null;
-  }
 
   return (
     <ConnectedSlider />

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-project/product-recommendations",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Extension will display retrieved product pipeline data from external providers. (ie. Boxalino, etc)",
   "license": "Apache-2.0",
   "scripts": {
@@ -12,15 +12,15 @@
     "dummy": ""
   },
   "devDependencies": {
-    "@shopgate/eslint-config": "^6.7.1",
-    "@shopgate/pwa-common": "^6.7.1",
-    "@shopgate/pwa-common-commerce": "^6.7.1",
-    "@shopgate/pwa-core": "^6.7.1",
-    "@shopgate/engage": "^6.7.1",
+    "@shopgate/eslint-config": "^6.8.0",
+    "@shopgate/pwa-common": "^6.8.0",
+    "@shopgate/pwa-common-commerce": "^6.8.0",
+    "@shopgate/pwa-core": "^6.8.0",
+    "@shopgate/engage": "^6.8.0",
     "jest": "^22.4.2",
-    "@shopgate/pwa-unit-test": "^6.7.1",
-    "@shopgate/pwa-ui-ios": "^6.7.1",
-    "@shopgate/pwa-ui-shared": "^6.7.1",
+    "@shopgate/pwa-unit-test": "^6.8.0",
+    "@shopgate/pwa-ui-ios": "^6.8.0",
+    "@shopgate/pwa-ui-shared": "^6.8.0",
     "babel-core": "^6.26.0",
     "babel-plugin-react-transform": "^3.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
@@ -41,6 +41,6 @@
     "react-transform-catch-errors": "^1.0.2"
   },
   "peerDependenciees": {
-    "@shopgate/engage": "^6.7.1"
+    "@shopgate/engage": "^6.8.0"
   }
 }


### PR DESCRIPTION
I removed the timeout workaround since it is no longer needed as of PWA 6.8+
I tested with my shop: 31113 and attached https://github.com/shopgate-professional-services/ext-product-recommendations-mocked-backend. I changed the search param to: bumble to return a group of products since '*' didn't seem to return products for me. I also changed config to have:
{
"cartPage": {
"h2": "Unsere Empfehlungen",
"h3": "Basierend auf deinem Warenkorb",
"position": "cart.coupon-field.after",
"textColor": "#fff",
"background": "#3BAC5B"
},
"recommendationsPage": {
"h2": "Deine persönlichen Empfehlungen",
"h3": "Basierend auf den Daten die wir haben ;)",
"title": "Deine Empfehlungen",
"textColor": "#fff",
"background": "#3BAC5B"
},
"productPage": {
"h2": "Unsere Empfehlungen",
"h3": "Kunden kauften auch",
"position": "product.header.after",
"textColor": "#fff",
"background": "#3BAC5B"
}
}

To recreate issue you must navigate to a product, navigate away, and return to product with PWA versions before 6.7.2.

The issue is resolved with PWA 6.8.0

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md