### PR TITLE
Extended ProductSlider props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.4.0] - 2024-06-21
+## Added
+- Adjust ProductSlider scope for Recommendations needed for tracking
+
 ## [1.3.0] - 2024-06-27
 ## Added
 - Options to customize the `getProductRecommendations` request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [1.4.0] - 2024-06-21
 ## Added
-- Adjust ProductSlider scope for Recommendations needed for tracking
+- Set ProductSlider.meta which is needed for tracking
 
 ## [1.3.1] - 2024-08-26
 ## Added

--- a/frontend/components/Slider/index.jsx
+++ b/frontend/components/Slider/index.jsx
@@ -17,7 +17,10 @@ const wrapper = css({
  * @param {Object} props props
  * @returns {JSX}
  */
-const Slider = ({ products, type, settings }) => {
+const Slider = ({
+  products, type, settings, id,
+  requestOptions,
+}) => {
   const { ProductSlider } = useTheme();
   const { push } = useNavigation();
 
@@ -38,7 +41,16 @@ const Slider = ({ products, type, settings }) => {
   return (
     <div className={wrapper}>
       <Header {...headerProps} />
-      <ProductSlider productIds={productIds} />
+      <ProductSlider
+        productIds={productIds}
+        scope={{
+          isRecommendation: true,
+          recommendationScope: {
+            id,
+            position: requestOptions.position,
+          },
+        }}
+      />
       {CTAText && ((
         <Button
           className={styles.button(CTABackgroundColor, CTAColor)}
@@ -52,12 +64,14 @@ const Slider = ({ products, type, settings }) => {
 };
 
 Slider.propTypes = {
+  id: PropTypes.string,
   products: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
     ]),
   })),
+  requestOptions: PropTypes.shape(),
   settings: PropTypes.shape(),
   type: PropTypes.string,
 };

--- a/frontend/components/Slider/index.jsx
+++ b/frontend/components/Slider/index.jsx
@@ -50,6 +50,7 @@ const Slider = ({
           isRecommendation: true,
           recommendationScope: {
             id,
+            type,
             requestOptions,
           },
         }}
@@ -83,6 +84,8 @@ Slider.defaultProps = {
   products: null,
   type: null,
   settings: null,
+  id: null,
+  requestOptions: null,
 };
 
 export default Slider;

--- a/frontend/components/Slider/index.jsx
+++ b/frontend/components/Slider/index.jsx
@@ -18,7 +18,10 @@ const wrapper = css({
  * @returns {JSX}
  */
 const Slider = ({
-  products, type, settings, id,
+  products,
+  type,
+  settings,
+  id,
   requestOptions,
 }) => {
   const { ProductSlider } = useTheme();
@@ -47,7 +50,7 @@ const Slider = ({
           isRecommendation: true,
           recommendationScope: {
             id,
-            position: requestOptions.position,
+            requestOptions,
           },
         }}
       />

--- a/frontend/components/Slider/index.jsx
+++ b/frontend/components/Slider/index.jsx
@@ -46,7 +46,7 @@ const Slider = ({
       <Header {...headerProps} />
       <ProductSlider
         productIds={productIds}
-        scope={{
+        meta={{
           isRecommendation: true,
           recommendationScope: {
             id,

--- a/frontend/connectors/withRecommendations.jsx
+++ b/frontend/connectors/withRecommendations.jsx
@@ -24,6 +24,8 @@ const WithRecommendations = ({
     products={products}
     limit={limit}
     type={type}
+    id={id}
+    requestOptions={requestOptions}
     {...props}
   />);
 };


### PR DESCRIPTION
## Description
Added "meta" prop to ProductSlider component. This prop is used to provide additional information about the slider context, and is injected to the PDP route state when slider product is opened.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update
