### PR TITLE
Enabled multiple slider names on the same page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.6.0
+## 1.5.1
 ## Added
 - Support for multiple slider titles on the same page via additional `header` property inside `requestOptions` entries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## 1.5.1
 ## Added
 - Support for multiple slider titles on the same page via additional `header` property inside `requestOptions` entries
+- Allowed to configure `requestOptions` inside the widget settings, so there is no need anymore to configure the same settings inside the CMS page configuration and the extension config
 
 ## 1.5.0
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Upcoming
+### Added
+- Support for multiple slider titles on the same page via additional `header` property inside `requestOptions` entries
+
 ## [1.4.0] - 2024-06-21
 ## Added
 - Set ProductSlider.meta which is needed for tracking

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Settings for the recommendation page
 	- `product.reviews.after`
 	- `cart.coupon-field.before`
 	- `cart.coupon-field.after`
-- `requestOptions` (optional): Options to customize the `getProductRecommendations` request and the portal positions. If this array is set, the other configs for `recommendationsPage`, `cartPage` and `productPage` will be ignored. For each option, `position` and `pattern` are mandatory. The `widgetName` key is required as soon as a option has the value `widget` for the `position` key. Its value must match the widget setting `name`.<br>
+- `requestOptions` (optional): Options to customize the `getProductRecommendations` request and the portal positions. If this array is set, the other configs for `recommendationsPage`, `cartPage` and `productPage` will be ignored. For each option, `position` and `pattern` are mandatory. The `widgetName` key is required as soon as a option has the value `widget` for the `position` key. Its value must match the widget setting `name`.
+When multiple sliders are configured for a single page, their headers can be customized via an optional `header` property. Its value is an object with the properties `h2`, `h3`, `background` and `textColor`.
+<br>
 Possible portal positions:
 	- `product.header.after`,
 	- `product.description.before`,
@@ -106,7 +108,13 @@ Possible portal positions:
       ],
       "parameter_2": "PRODUCT",
       "position": "product.properties.before",
-      "pattern": "/item/:productId"
+      "pattern": "/item/:productId",
+      "header": {
+        "h2": "Custom header for product page slider",
+        "h3": "",
+        "background": "",
+        "textColor": ""
+      }
     },
     {
       "parameter_1": [

--- a/README.md
+++ b/README.md
@@ -9,13 +9,19 @@ Extension will display retrieved product pipeline data from external providers. 
   "settings": {
     "name": "example-campaign-4",
     "h3": "PRODUKTEMPFEHLUNGEN",
-    "h2": "Deine<br> personliche<br> Auswahl",
+    "h2": "Deine<br> persönliche<br> Auswahl",
     "background": "#fff",
     "textColor": "#000",
     "limit": 6,
     "CTABackgroundColor": "green",
     "CTAColor": "white",
-    "CTAText": "Zu deinen Empfehlungen"
+    "CTAText": "Zu deinen Empfehlungen",
+    "requestOptions": {
+      "parameter_1": [
+        "requestOptions property is completely optional"
+      ],
+      "parameter_2": "CATEGORY",
+    }
   }
 }
 -->

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0",
+  "version": "1.5.1",
   "id": "@shopgate-project/product-recommendations",
   "components": [
     {

--- a/frontend/components/Slider/index.jsx
+++ b/frontend/components/Slider/index.jsx
@@ -31,7 +31,10 @@ const Slider = ({
     return null;
   }
 
-  const headerProps = settings || (type === RECOMMENDATION_TYPE_CART ? cartPage : productPage);
+  const headerProps =
+    requestOptions?.header ||
+    settings ||
+    (type === RECOMMENDATION_TYPE_CART ? cartPage : productPage);
 
   const productIds = products.map(p => p.id);
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-project/product-recommendations",
-  "version": "1.6.0",
+  "version": "1.5.1",
   "description": "Extension will display retrieved product pipeline data from external providers. (ie. Boxalino, etc)",
   "license": "Apache-2.0",
   "scripts": {

--- a/frontend/widgets/ProductRecommendations/index.jsx
+++ b/frontend/widgets/ProductRecommendations/index.jsx
@@ -19,14 +19,22 @@ const ProductRecommendations = ({
   const { pathname } = useRoute();
 
   const pageWidgetRequestOptions = useMemo(() => {
-    if (!Array.isArray(requestOptionsConfig) || requestOptionsConfig.length === 0) {
+    if (
+      (!Array.isArray(requestOptionsConfig) || requestOptionsConfig.length === 0) &&
+      !settings?.requestOptions
+    ) {
       // No request options - no config for page widgets
       return null;
     }
-
-    const requestOptions = requestOptionsConfig.find(option => option.position === 'widget' &&
+    // Check if the request options array contains a config for the current widget
+    let requestOptions = requestOptionsConfig.find(option => option.position === 'widget' &&
       option.pattern === pathname &&
       option.widgetName === name);
+
+    // Check if the widget settings contain a request options
+    if (!requestOptions && settings?.requestOptions) {
+      requestOptions = settings.requestOptions
+    }
 
     if (!requestOptions) {
       // No matching request option - no config for page widgets


### PR DESCRIPTION
## Description
This pull request enables to configure multiple sliders on a single page with dedicated headers. It extends the properties that can be configured with the `requestOptions` entries and adds support for the new `header` property.

Additionally it's now possible to configure `requestOptions` inside the settings of recommendation widgets.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md