### PR TITLE
Add support for product expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.6.0
+### Added
+- Added support for product data expiration
+
 ## 1.5.2
 ## Added
 - Added support for Recommendations widget display modes (slider (default) or product list); configure via the widget configuration’s `settings.type` property (`slider` or `list`).

--- a/frontend/connectors/withRecommendations.jsx
+++ b/frontend/connectors/withRecommendations.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { getRecommendationsForType } from '../selectors';
+import { getRecommendationsForType, getRecommendationsStateForType } from '../selectors';
 import { fetchRecommendations } from '../actions';
+import { RECOMMENDATION_TYPE_PRODUCT } from '../constants';
 
 // eslint-disable-next-line require-jsdoc
 const WithRecommendations = ({
@@ -14,11 +15,20 @@ const WithRecommendations = ({
   // eslint-disable-next-line no-shadow
   fetchRecommendations,
   requestOptions,
+  state,
   ...props
 }) => {
   useEffect(() => {
     fetchRecommendations(type, id, requestOptions);
   }, [type, id, requestOptions, fetchRecommendations]);
+
+  // This ensures that the recommendations will be fetched again is the data is expired
+  useEffect(() => {
+    if (state && !state.isFetching && state.expires === 0 && type === RECOMMENDATION_TYPE_PRODUCT) {
+      fetchRecommendations(type, id, requestOptions);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state?.isFetching, state?.expires, type]);
 
   return (<WrappedComponent
     products={products}
@@ -57,6 +67,7 @@ WithRecommendations.defaultProps = {
  */
 const mapStateToProps = (state, props) => ({
   products: getRecommendationsForType(state, props),
+  state: getRecommendationsStateForType(state, { type: props.type }),
 });
 
 /**

--- a/frontend/connectors/withRecommendations.jsx
+++ b/frontend/connectors/withRecommendations.jsx
@@ -67,7 +67,7 @@ WithRecommendations.defaultProps = {
  */
 const mapStateToProps = (state, props) => ({
   products: getRecommendationsForType(state, props),
-  state: getRecommendationsStateForType(state, { type: props.type }),
+  state: getRecommendationsStateForType(state, props),
 });
 
 /**

--- a/frontend/reducers/index.js
+++ b/frontend/reducers/index.js
@@ -93,9 +93,27 @@ const recommendationsByType = (
 
     case ERROR_RECOMMENDATIONS:
     case CLEAR_RECOMMENDATIONS:
+      const playloadTypeState = state[payload.type] || {};
+
+      if (payload?.type === RECOMMENDATION_TYPE_PRODUCT) {
+        // Expire all positions of all products
+        Object.keys(playloadTypeState).forEach((key) => {
+          if (playloadTypeState[key].positions) {
+            Object.keys(playloadTypeState[key].positions).forEach((positionKey) => {
+              playloadTypeState[key].positions[positionKey] = {
+                ...playloadTypeState[key].positions[positionKey],
+                isFetching: false,
+                expires: 0,
+              };
+            });
+          }
+        });
+      }
+
       return wrapData(state, payload, {
         isFetching: false,
         expires: 0,
+        ...playloadTypeState,
       });
     default:
       return state;

--- a/frontend/subscriptions/index.js
+++ b/frontend/subscriptions/index.js
@@ -2,9 +2,10 @@ import { userDidLogin$, userDidLogout$ } from '@shopgate/engage/user';
 import { remoteCartDidUpdate$ } from '@shopgate/pwa-common-commerce/cart/streams';
 import { getCurrentPathname } from '@shopgate/pwa-common/selectors/router';
 import { CART_PATH } from '@shopgate/pwa-common-commerce/cart/constants';
+import { productDataExpired$ } from '@shopgate/engage/product';
 import { fetchRecommendations, fetchUserRecommendations } from '../actions';
-import { clearRecommendations } from '../action-creators';
-import { RECOMMENDATION_TYPE_CART } from '../constants';
+import { clearRecommendations, expireRecommendations } from '../action-creators';
+import { RECOMMENDATION_TYPE_CART, RECOMMENDATION_TYPE_PRODUCT } from '../constants';
 
 /**
  * Subscriptions
@@ -24,6 +25,10 @@ const recommendationSubscriptions = (subscribe) => {
       // we need to re-fetch in case the cart page is visible at this point
       dispatch(fetchRecommendations(RECOMMENDATION_TYPE_CART));
     }
+  });
+
+  subscribe(productDataExpired$, ({ dispatch }) => {
+    dispatch(clearRecommendations(RECOMMENDATION_TYPE_PRODUCT));
   });
 };
 


### PR DESCRIPTION
This pull request adds support for the new product expiration system. Whenever the expireProductData Redux action is dispatched, the extension will re-fetch its product data.