### PR TITLE
CURB-5831 Add disableCache property to requestOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.6.1
+### Added
+- Added support for disabling Redux cache via the request options (add `disableCache: true` to the config)
+
 ## 1.6.0
 ### Added
 - Added support for product data expiration

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Possible portal positions:
       ],
       "parameter_2": "CATEGORY",
       "position": "product.list.before",
-      "pattern": "/category/:categoryId"
+      "pattern": "/category/:categoryId",
+      "disableCache": true
     },
     {
       "parameter_1": [

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0",
+  "version": "1.6.1-beta.1",
   "id": "@shopgate-project/product-recommendations",
   "components": [
     {

--- a/frontend/actions/index.js
+++ b/frontend/actions/index.js
@@ -31,7 +31,20 @@ export const fetchRecommendations = (type, id = null, requestOptions = null) =>
       requestOptions,
     });
 
-    if (recommendations && !shouldFetchData(recommendations)) {
+    let forceFetch = false;
+
+    /**
+     * When the disableCache flag is set, we want to force a new request whenever the action is
+     * dispatched. However on PDP the action might be dispatched twice in quick succession,
+     * so we only want to force a fetch if there is no request in flight already.
+     */
+    if (requestOptions?.disableCache ?? false) {
+      if (recommendations?.isFetching === false) {
+        forceFetch = true;
+      }
+    }
+
+    if (recommendations && !shouldFetchData(recommendations) && !forceFetch) {
       return Promise.resolve();
     }
 

--- a/frontend/connectors/withRecommendations.jsx
+++ b/frontend/connectors/withRecommendations.jsx
@@ -50,6 +50,10 @@ WithRecommendations.propTypes = {
     id: PropTypes.string.isRequired,
   })),
   requestOptions: PropTypes.shape(),
+  state: PropTypes.shape({
+    isFetching: PropTypes.bool,
+    expires: PropTypes.number,
+  }),
 };
 
 WithRecommendations.defaultProps = {
@@ -57,6 +61,7 @@ WithRecommendations.defaultProps = {
   products: null,
   id: null,
   requestOptions: null,
+  state: null,
 };
 
 /**

--- a/frontend/reducers/index.js
+++ b/frontend/reducers/index.js
@@ -92,16 +92,16 @@ const recommendationsByType = (
     }
 
     case ERROR_RECOMMENDATIONS:
-    case CLEAR_RECOMMENDATIONS:
-      const playloadTypeState = state[payload.type] || {};
+    case CLEAR_RECOMMENDATIONS: {
+      const payloadTypeState = state[payload.type] || {};
 
       if (payload?.type === RECOMMENDATION_TYPE_PRODUCT) {
         // Expire all positions of all products
-        Object.keys(playloadTypeState).forEach((key) => {
-          if (playloadTypeState[key].positions) {
-            Object.keys(playloadTypeState[key].positions).forEach((positionKey) => {
-              playloadTypeState[key].positions[positionKey] = {
-                ...playloadTypeState[key].positions[positionKey],
+        Object.keys(payloadTypeState).forEach((key) => {
+          if (payloadTypeState[key].positions) {
+            Object.keys(payloadTypeState[key].positions).forEach((positionKey) => {
+              payloadTypeState[key].positions[positionKey] = {
+                ...payloadTypeState[key].positions[positionKey],
                 isFetching: false,
                 expires: 0,
               };
@@ -113,8 +113,10 @@ const recommendationsByType = (
       return wrapData(state, payload, {
         isFetching: false,
         expires: 0,
-        ...playloadTypeState,
+        ...payloadTypeState,
       });
+    }
+
     default:
       return state;
   }

--- a/frontend/selectors/index.js
+++ b/frontend/selectors/index.js
@@ -44,10 +44,16 @@ export const getRecommendationsStateForType = createSelector(
 
 export const getRecommendationsForType = createSelector(
   getRecommendationsStateForType,
+  (_, { id }) => id,
   (_, { limit }) => limit,
-  (recommendationsState, limit) =>
-    (recommendationsState && recommendationsState.products ?
-      recommendationsState.products.slice(0, limit) : null)
+  (recommendationsState, productId, limit) => (
+    recommendationsState && recommendationsState.products ?
+      recommendationsState.products
+        // Remove the current visible product from the list
+        .filter(({ id, baseProductId }) => (baseProductId || id) !== productId)
+        .slice(0, limit) : null
+  )
+
 );
 
 /**

--- a/frontend/subscriptions/index.js
+++ b/frontend/subscriptions/index.js
@@ -4,7 +4,7 @@ import { getCurrentPathname } from '@shopgate/pwa-common/selectors/router';
 import { CART_PATH } from '@shopgate/pwa-common-commerce/cart/constants';
 import { productDataExpired$ } from '@shopgate/engage/product';
 import { fetchRecommendations, fetchUserRecommendations } from '../actions';
-import { clearRecommendations, expireRecommendations } from '../action-creators';
+import { clearRecommendations } from '../action-creators';
 import { RECOMMENDATION_TYPE_CART, RECOMMENDATION_TYPE_PRODUCT } from '../constants';
 
 /**


### PR DESCRIPTION
# Description

Redux cache can be disabled for specific configs.  Can be useful when recommendations are supposed to be re-fetched for every page:

Example:

```json
{
  "requestOptions": [
    {
      "type": "PRODUCT",
      "names": [],
      "header": {},
      "pattern": "/item/:productId",
      "position": "product.description.after",
      "widgetName": "",
      "disableCache": true
    }
  ]
}
```

# Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update